### PR TITLE
20230424_use_official_healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
          - [Drupal Symfony Mailer](#drupal-symfony-mailer)
          - [SMTP Authentication Support](#smtp-authentication-support)
 - [Configuration](#configuration)
-   - [Mailhog](#mailhog)
+   - [Replacing Mailhog](#replacing-mailhog)
 - [TODO](#todo)
 - [Contributing](#contributing)
 
@@ -125,7 +125,7 @@ This addon uses 2 environment variables that can be set :
 
 See [Providing Custom Environment Variables to a Container](https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-environment-variables-to-a-container) for methods to set these values.
 
-### Mailhog
+### Replacing Mailhog
 
 This addon is currently designed as a drop-in replacement for Mailhog.
 
@@ -138,6 +138,19 @@ To change the Mailhog UI port, update `.ddev/config.mailpit.yaml`:
 mailhog_port: "9025"
 mailhog_https_port: "9026"
 ```
+
+By default, `ddev launch -m` will open MailHog.
+You can update the command to open Mailpit for your project instead by making the following changes.
+
+1. Copy your global `~/.ddev/commands/host/launch` into your project folder to `.ddev/commands/host/launch`.
+1. Remove `#ddev-generated` from your project's `.ddev/commands/host/launch` command.
+1. Replace the Mailhog section with the following from your project's `.ddev/commands/host/launch`
+
+      ```bash
+         -m|--mailhog)
+            FULLURL="${FULLURL%:[0-9]*}:8026"
+         ;;
+      ```
 
 ## TODO
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -15,8 +15,9 @@ health_checks() {
   # Confirm site is available. ie. DDEV didn't fail
   ddev exec "curl -s https://localhost:443/"
 
-  # Confirm Mailpit UI is available; it displays an error because it expects Javascript
-  ddev exec "curl -s mailpit:8025" | grep "You require JavaScript to use this app."
+  # Check Healthcheck endpoints. https://github.com/axllent/mailpit/wiki/Healthcheck-endpoints
+  ddev exec "curl --silent --head mailpit:8025/livez" | grep "HTTP/1.1 200 OK"
+  ddev exec "curl --silent --head mailpit:8025/readyz" | grep "HTTP/1.1 200 OK"
 }
 
 teardown() {


### PR DESCRIPTION
This PR improves the health check during the tests.

It uses the 2 official HTTP endpoints for the Docker image.

@see https://github.com/axllent/mailpit/wiki/Healthcheck-endpoints