### PR TITLE
Bump Mailpit version

### DIFF
--- a/docker-compose.mailpit.yaml
+++ b/docker-compose.mailpit.yaml
@@ -3,7 +3,7 @@
 services:
   mailpit:
     container_name: "ddev-${DDEV_SITENAME}-mailpit"
-    image: axllent/mailpit:v1.5.4
+    image: axllent/mailpit:v1.6.3
     networks: [default, ddev_default]
     expose:
       - ${MAILPIT_PORT:-1025}


### PR DESCRIPTION
This PR bumps Mailpit to `1.6.0`.

This version is required for SMTP relay feature.