### PR TITLE
add SMTP relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
          - [SMTP Authentication Support](#smtp-authentication-support)
 - [Configuration](#configuration)
    - [Replacing Mailhog](#replacing-mailhog)
+   - [SMTP relay](#smtp-relay)
+      - [Forward all mail](#forward-all-mail)
 - [TODO](#todo)
 - [Contributing](#contributing)
 
@@ -151,6 +153,32 @@ You can update the command to open Mailpit for your project instead by making th
             FULLURL="${FULLURL%:[0-9]*}:8026"
          ;;
       ```
+
+### SMTP relay
+
+Mailpit can be configured to allow you to forward emails to another SMTP.
+This addon automatically sets up the configuration file, however, you will need to update the
+specific settings for you SMTP server to use.
+
+Update your project's `.ddev/mailpit/config.yaml` file:
+
+1. Remove `#ddev-generated`.
+1. Add your SMTP server details.
+
+See [SMTP replay](https://github.com/axllent/mailpit/wiki/SMTP-relay) for more details.
+
+#### Forward all mail
+
+To automatically relay _all_ mail, update `.ddev/docker-compose.mailpit.yaml`:
+
+1. Remove `#ddev-generated`.
+1. Add `MP_SMTP_RELAY_ALL` environmental variable.
+
+   ```yaml
+    environment:
+      ...
+      - MP_SMTP_RELAY_ALL=TRUE
+   ```
 
 ## TODO
 

--- a/docker-compose.mailpit.yaml
+++ b/docker-compose.mailpit.yaml
@@ -9,9 +9,14 @@ services:
       - ${MAILPIT_PORT:-1025}
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - MP_SMTP_BIND_ADDR=0.0.0.0:${MAILPIT_PORT:-1025}
       - HTTP_EXPOSE=${MAILPIT_UI_PORT:-8025}:${MAILPIT_UI_PORT:-8025}
       - HTTPS_EXPOSE=8026:${MAILPIT_UI_PORT:-8025}
+      - MP_SMTP_BIND_ADDR=0.0.0.0:${MAILPIT_PORT:-1025}
+      - MP_SMTP_RELAY_CONFIG=/tmp/config.yaml
+      # Uncomment the below line after updating `./.ddev/mailpit/config.yaml` to relay ALL mail to your SMTP server.
+      # - MP_SMTP_RELAY_ALL=TRUE
+    volumes:
+      - ./mailpit/config.yaml:/tmp/config.yaml
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT

--- a/install.yaml
+++ b/install.yaml
@@ -8,6 +8,7 @@ project_files:
 - docker-compose.mailpit.yaml
 - config.mailpit.yaml
 - mailpit/config.yaml
+- mailpit/.gitignore
 
 # OOTB, Drupal projects use PHP's mail function. Below, we check for this and update
 # the server from default to 'mailpit'

--- a/install.yaml
+++ b/install.yaml
@@ -7,6 +7,7 @@ name: ddev-mailpit
 project_files:
 - docker-compose.mailpit.yaml
 - config.mailpit.yaml
+- mailpit/config.yaml
 
 # OOTB, Drupal projects use PHP's mail function. Below, we check for this and update
 # the server from default to 'mailpit'

--- a/mailpit/.gitignore
+++ b/mailpit/.gitignore
@@ -1,0 +1,2 @@
+#ddev-generated
+config.yaml

--- a/mailpit/config.yaml
+++ b/mailpit/config.yaml
@@ -1,0 +1,13 @@
+#ddev-generated
+
+# You must update the host with your SMTP host server.
+# Mailpit will fail if a valid entry is NOT configured so an example is provided below.
+host:             sandbox.smtp.mailtrap.io      # required
+# port:           <port>                # optional - default 25
+# starttls:       <true|false>          # optional - default false
+# allow-insecure: <true|false>          # optional - default false
+# auth:           <none|plain|cram-md5> # optional - default none
+# username:       <username>            # required for both plain or cram-md5 auth
+# password:       <password>            # required for plain auth
+# secret:         <cram-secret>         # required for cram-md5 auth
+# return-path:    <bounce-address>      # optional - overrides Return-Path for all released emails


### PR DESCRIPTION
This PR adds SMTP relay feature. 
It requires Mailpit > `1.6.0`

This PR is currently a "draft". It does not prevent sensitive SMTP server settings from being accidently committed into a project's repo.