### PR TITLE
🔓 update Github workflow permission

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,9 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: write
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
This PR resolves a "unable to access" error message during action tests.

See gautamkrishnar/keepalive-workflow#14