### PR TITLE
📓 Update Laravel settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ Some of the features listed on the Mailpit repo page include:
 
 ### Laravel
 
-1. Update your project's `.env` file:
+1. Disable DDEV's setting management.
+
+   ```shell
+   ddev config --disable-settings-management=true
+   ```
+
+1. Update your project's `.env` file. If these setting keep changing, you may need to disable DDEV's setting management.
 
    ```shell
    MAIL_MAILER=smtp


### PR DESCRIPTION
This PR updates docs for Laravel.

By default, DDEV will override the `MAIL_HOST` in `.env` with `127.0.0.1`.

However, this addon uses `mailpit` as the `MAIL_HOST`. 

This PR instructs developers to change the setting for the current project to prevent overrides.