### PR TITLE
Update PHP's sendmail with mailpit

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Some of the features listed on the Mailpit repo page include:
 
 Drupal uses the PHP mail function to send mail. On install this addon tries to detect Drupal projects and will write a custom PHP `ini` (`.ddev/php/mailpit.ini`) to set the mail host to `mailpit`.
 
+1. Override DDEV mail settings in `settings.local.php`.
+
+   ```php
+   $config['symfony_mailer.mailer_transport.sendmail']['configuration']['host']='mailpit';
+   ```
+
+`settings.ddev.php` sets this value to 'localhost'. Please ensure the above setting is *after* loading `settings.ddev.php`.
+
 If you plan on using the "SMTP (recommended)" method below, `.ddev/php/mailpit.ini` can be safely deleted.
 
 #### SMTP (recommended)
@@ -179,7 +187,7 @@ See [SMTP replay](https://github.com/axllent/mailpit/wiki/SMTP-relay) for more d
 
 #### Forward all mail
 
-To automatically relay _all_ mail, update `.ddev/docker-compose.mailpit.yaml`:
+To automatically relay *all* mail, update `.ddev/docker-compose.mailpit.yaml`:
 
 1. Remove `#ddev-generated`.
 1. Add `MP_SMTP_RELAY_ALL` environmental variable.

--- a/docker-compose.mailpit.yaml
+++ b/docker-compose.mailpit.yaml
@@ -20,3 +20,8 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
+
+  web:
+    volumes:
+      # Map the mailpit executable into the web container
+      - ./mailpit:/usr/local/bin/mailpit

--- a/install.yaml
+++ b/install.yaml
@@ -14,13 +14,11 @@ project_files:
 # the server from default to 'mailpit'
 post_install_actions:
 - |
-  if [[ "${DDEV_PROJECT_TYPE}" == "drupal"* ]]; then
-  #ddev-description:Drupal project detected. Adding custom PHP mail settings.
+  #ddev-description:Adding custom PHP mail settings.
     mkdir -p php
     echo '# #ddev-generated
   # Update web container PHP to use mailpit server
   [mail function]
   SMTP="mailpit"
-  sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr mailpit:1025"
+  sendmail_path="/usr/local/bin/mailpit sendmail test@example.org --smtp-addr mailpit:1025"
   ' > php/mailpit.ini
-  fi


### PR DESCRIPTION
This PR updates the project's PHP sendmail settings.

Previously, this was only added for Drupal projects, and still used the `mailhog` executable to do send mail.

This PR
- maps `mailpit` into the web container at `/usr/local/bin/mailpit`
- writes a custom PHP ini file to use mailpit for sendmail.

This should allow the addon to function if/when mailhog is removed from the web container.