### PR TITLE
Fix `launch` command docs for Gitpod & Codespaces environments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,11 @@ You can update the command to open Mailpit for your project instead by making th
 
       ```bash
          -m|--mailhog)
-            FULLURL="${FULLURL%:[0-9]*}:8026"
+            if [[ ! -z "${GITPOD_INSTANCE_ID}" ]] || [[ "${CODESPACES}" == "true" ]]; then
+                FULLURL="${FULLURL/-${DDEV_HOST_WEBSERVER_PORT}/-${MAILPIT_UI_PORT:-8026}}"
+            else
+                FULLURL="${FULLURL%:[0-9]*}:${MAILPIT_UI_PORT:-8026}"
+            fi
          ;;
       ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ Some of the features listed on the Mailpit repo page include:
 
 ### Laravel
 
-1. Update your project's `.env` file:
+1. Disable DDEV's setting management.
+
+   ```shell
+   ddev config --disable-settings-management=true
+   ```
+
+1. Update your project's `.env` file. If these setting keep changing, you may need to disable DDEV's setting management.
 
    ```shell
    MAIL_MAILER=smtp


### PR DESCRIPTION
This PR updates the docs instructions for updating the `launch -m`  command.

- update URL for Gitpod environment
- update URL for Codespaces environment
- default to ENV setting or failback.

Currently, `MAILPIT_UI_PORT` is not set by this addon for the host. If not set, it falls back to `8026`.