### PR TITLE
Change name to mailpit?

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,4 +1,4 @@
-name: ddev-mailpit
+name: mailpit
 
 # list of files and directories listed that are copied into project .ddev directory
 # Each file should contain #ddev-generated so it can be replaced by a later `ddev get`


### PR DESCRIPTION
I just installed for testing and noted the name was `ddev-mailpit` and maybe `mailpit` would be better? Your call on this.

Random other thoughts:
* We now have post-removal actions, and adding a post-removal action to remind people to reconfigure their php or other configuration would be a good thing.